### PR TITLE
Use separate variables instead of casting.

### DIFF
--- a/src/r20_plane.c
+++ b/src/r20_plane.c
@@ -50,6 +50,7 @@ void obj_plane_init (obj_plane *p, shader_material *mat, int width, int height, 
 void obj_plane_render (obj_plane *p, obj_model *models, unsigned int models_amnt, obj_light *lights, unsigned int lights_amnt, bmp_pixel **pxls, int width, int height, vectorf *cam, char texture_gen (obj_texturedata*))
 {
 	unsigned int x, y;
+	int px, py;
 	vectorf pos, t;
 	obj_texturedata td;
 	
@@ -71,21 +72,23 @@ void obj_plane_render (obj_plane *p, obj_model *models, unsigned int models_amnt
 					break;
 			}
 			
-			obj_texturedata_init (&td, &pxls[(int)pos.y][(int)pos.x], (int)t.x, (int)t.y, (int)t.z, 1);
+			obj_texturedata_init (&td, &pxls[py][px], (int)t.x, (int)t.y, (int)t.z, 1);
 			texture_gen (&td);
 			
 			vectorf_init (&t, td.x, td.y, td.z);
 			
 			pos = vectorf_to_twod (*cam, t, width, height);
+			px = (int)pos.x;
+			py = (int)pos.y;
 			
 			if (pos.x >= 0 && pos.x < width && pos.y >= 0 && pos.y < height)
 			{
-				obj_texturedata_init (&td, &pxls[(int)pos.y][(int)pos.x], (int)t.x, (int)t.y, (int)t.z, 0);
+				obj_texturedata_init (&td, &pxls[py][px], (int)t.x, (int)t.y, (int)t.z, 0);
 				
 				if (texture_gen (&td) == 0 && obj_model_check_shadow (models, models_amnt, &t) == false)
 				{
 					vectorf_init (&t, td.x, td.y, td.z);
-					obj_lights_render (lights, lights_amnt, p->mat, cam, &t, &pxls[(int)pos.y][(int)pos.x]);
+					obj_lights_render (lights, lights_amnt, p->mat, cam, &t, &pxls[py][px]);
 				}
 			}	
 		}


### PR DESCRIPTION
Instead of casting the positions each time it needs to be an int like when it be used as an index for an array, an separate variable will be used.
